### PR TITLE
Pin dependencies

### DIFF
--- a/requirements.ci.txt
+++ b/requirements.ci.txt
@@ -1,6 +1,6 @@
 ansible-lint
-molecule
+molecule==24.12.0
 molecule-plugins[docker]
-docker
+docker~=7.1.0
 requests==2.31.0  # pinned to the latest version not breaking Docker SDK
 yamllint

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible
+ansible~=11.1.0


### PR DESCRIPTION
Prompted by what we discovered in https://github.com/ansible/molecule/issues/4372

Pinning the currently working version of Molecule and Docker SDK.